### PR TITLE
Updates to version command to print additional build info

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	"runtime"
+
+	"github.com/containerd/containerd/platforms"
 	"github.com/fatih/color"
 	"github.com/intelops/genval/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -12,11 +15,29 @@ var versionCmd = &cobra.Command{
 	Short: "Prints Genval version information",
 	Long:  `All software has versions. This is Genval's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		Version, err := utils.GetVersion()
+		version, commitHash, buildTime, err := utils.FetchVersionInfo()
 		if err != nil {
-			log.Errorf("Error fetching version info: %v", err)
+			return
 		}
-		color.New(color.FgHiCyan, color.Bold).Println(Version)
+		color.New(color.FgHiCyan, color.Bold).Println(`
+		:'######:::'########:'##::: ##:'##::::'##::::'###::::'##:::::::
+		:##... ##:: ##.....:: ###:: ##: ##:::: ##:::'## ##::: ##:::::::
+		:##:::..::: ##::::::: ####: ##: ##:::: ##::'##:. ##:: ##:::::::
+		:##::'####: ######::: ## ## ##: ##:::: ##:'##:::. ##: ##:::::::
+		:##::: ##:: ##...:::: ##. ####:. ##:: ##:: #########: ##:::::::
+		:##::: ##:: ##::::::: ##:. ###::. ## ##::: ##.... ##: ##:::::::
+		: ######::: ########: ##::. ##:::. ###:::: ##:::: ##: ########:
+		:......::::........::..::::..:::::...:::::..:::::..::........::
+
+		genval is a CLI tool to generate and validate configuration files
+
+		`)
+		fmt.Printf("Version:\t%s\n", version)
+		fmt.Printf("Git Commit:\t%s\n", commitHash)
+		fmt.Printf("OS/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Go version:\t%s\n", runtime.Version())
+		fmt.Printf("Build date:\t%s\n", buildTime)
+		fmt.Printf("Build platform:\t%s\n", platforms.DefaultString())
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cuelang.org/go v0.8.2
 	github.com/briandowns/spinner v1.23.0
+	github.com/containerd/containerd v1.7.15
 	github.com/fatih/color v1.16.0
 	github.com/google/cel-go v0.20.1
 	github.com/google/go-containerregistry v0.19.1
@@ -43,6 +44,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
@@ -89,6 +91,7 @@ require (
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
+	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/coreos/go-oidc/v3 v3.10.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
+github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
@@ -201,6 +203,10 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
+github.com/containerd/containerd v1.7.15 h1:afEHXdil9iAm03BmhjzKyXnnEBtjaLJefdU7DV0IFes=
+github.com/containerd/containerd v1.7.15/go.mod h1:ISzRRTMF8EXNpJlTzyr2XMhN+j9K302C21/+cr3kUnY=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
+github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/coreos/go-oidc/v3 v3.10.0 h1:tDnXHnLyiTVyT/2zLDGj09pFPkhND8Gl8lnTRhoEaJU=

--- a/pkg/oci/ociClient.go
+++ b/pkg/oci/ociClient.go
@@ -298,7 +298,7 @@ func GetCreds() ([]crane.Option, error) {
 		opts = append(opts, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
-	userAgent, err := utils.GetVersion()
+	userAgent, _, _, err := utils.FetchVersionInfo()
 	if err != nil {
 		log.Errorf("Error fetching version info: %v", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -409,33 +409,37 @@ func StartSpinner(msg string) *spinner.Spinner {
 	return s
 }
 
-func GetVersion() (string, error) {
-	// Create the command to list all tag
+func FetchVersionInfo() (string, string, string, error) {
+	// Create the command to list all tags and get the latest one
 	cmdGitRevList := exec.Command("git", "rev-list", "--tags", "--max-count=1")
 	var out bytes.Buffer
 	cmdGitRevList.Stdout = &out
 	if err := cmdGitRevList.Run(); err != nil {
-		return "", fmt.Errorf("error running git rev-list: %v", err)
+		return "", "", "", fmt.Errorf("error running git rev-list: %v", err)
 	}
-	latestTag := strings.TrimSpace(out.String())
+	latestTagCommit := strings.TrimSpace(out.String())
 
-	// Create the command to fetc the latest tag
-	cmdGitDescribe := exec.Command("git", "describe", "--tags", latestTag)
-	version, err := cmdGitDescribe.Output()
+	// Create the command to fetch the latest tag using the commit hash
+	cmdGitDescribe := exec.Command("git", "describe", "--tags", latestTagCommit)
+	versionOutput, err := cmdGitDescribe.Output()
 	if err != nil {
-		return "", fmt.Errorf("error running git describe: %v", err)
+		return "", "", "", fmt.Errorf("error running git describe: %v", err)
 	}
-	return fmt.Sprintf(`
-	:'######:::'########:'##::: ##:'##::::'##::::'###::::'##:::::::
-	'##... ##:: ##.....:: ###:: ##: ##:::: ##:::'## ##::: ##:::::::
-	 ##:::..::: ##::::::: ####: ##: ##:::: ##::'##:. ##:: ##:::::::
-	 ##::'####: ######::: ## ## ##: ##:::: ##:'##:::. ##: ##:::::::
-	 ##::: ##:: ##...:::: ##. ####:. ##:: ##:: #########: ##:::::::
-	 ##::: ##:: ##::::::: ##:. ###::. ## ##::: ##.... ##: ##:::::::
-	. ######::: ########: ##::. ##:::. ###:::: ##:::: ##: ########:
-	:......::::........::..::::..:::::...:::::..:::::..::........::
+	latestTag := strings.TrimSpace(string(versionOutput))
 
-	genval is a CLI tool to generate and validate configuration files
+	// Get the commit date for the latest tag
+	cmdGitLog := exec.Command("git", "log", "-1", "--format=%cI", latestTagCommit)
+	dateOutput, err := cmdGitLog.Output()
+	if err != nil {
+		return "", "", "", fmt.Errorf("error running git log: %v", err)
+	}
+	commitDateRaw := strings.TrimSpace(string(dateOutput))
+	// Parse the commit date and format it using time.ANSIC
+	commitDate, err := time.Parse(time.RFC3339, commitDateRaw)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error parsing commit date: %v", err)
+	}
+	formattedCommitDate := commitDate.Format(time.ANSIC)
 
-	Genval: %s`, strings.TrimSpace(string(version))), nil
+	return latestTag, latestTagCommit, formattedCommitDate, nil
 }


### PR DESCRIPTION
This PR makes enhancement to `version` command, to print additional build information

Updated output of `version` command:

```shell
➜  genval git:(version) ./bin/genval version

                :'######:::'########:'##::: ##:'##::::'##::::'###::::'##:::::::
                :##... ##:: ##.....:: ###:: ##: ##:::: ##:::'## ##::: ##:::::::
                :##:::..::: ##::::::: ####: ##: ##:::: ##::'##:. ##:: ##:::::::
                :##::'####: ######::: ## ## ##: ##:::: ##:'##:::. ##: ##:::::::
                :##::: ##:: ##...:::: ##. ####:. ##:: ##:: #########: ##:::::::
                :##::: ##:: ##::::::: ##:. ###::. ## ##::: ##.... ##: ##:::::::
                : ######::: ########: ##::. ##:::. ###:::: ##:::: ##: ########:
                :......::::........::..::::..:::::...:::::..:::::..::........::

                genval is a CLI tool to generate and validate configuration files


Version:        v0.1.2
Git Commit:     a4e242c368497b40e9f7337b8b0f4d1a78d73c8d
OS/Arch:        linux/amd64
Go version:     go1.22.2
Build date:     Mon May  6 23:55:15 2024
Build platform: linux/amd64
```

