### PR TITLE
Fix version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,13 @@ builds:
     - -trimpath
   ldflags:
   #   # CommitDate makes the release reproducible
-    - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
+    - -X main.Version={{ .Tag }}
+    - -X .Runtime.Goarch={{ .Arch }}
+    - -X .Runtime.Gooss={{ .Os }}
+    - -X main.Date={{ .CommitDate }}
+    - -X main.Commit={{ .FullCommit }}
+    - -X main.GitTreeState={{ .GitTreeState }}
+
 
 checksum:
   name_template: 'checksums.txt'

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,33 @@ TESTFLAGS=-v
 GOOS ?= linux
 GOARCH ?= amd64
 
+GIT_TAG ?= dirty-tag
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+
+SRCS = $(shell find . -iname "*.go")
+
+PKG ?= sigs.k8s.io/release-utils/version
+LDFLAGS=-buildid= -X $(PKG).gitVersion=$(GIT_VERSION) \
+        -X $(PKG).gitCommit=$(GIT_HASH) \
+        -X $(PKG).gitTreeState=$(GIT_TREESTATE) \
+        -X $(PKG).buildDate=$(BUILD_DATE)
+
+DIGEST ?=
+
+
 default: help
 
 help: ## Display this help.
@@ -40,4 +67,4 @@ lint: ## Run a linter on the codebase using golangci-lint.
 
 
 build: ## builds the GenVal app for defined OS/Arch by passing GOOS=$(GOOS) GOARCH=$GOARCH args.| Example usage `make build GOOS=linux GOARCH=amd64`
-	@GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="-X main.Version=$(shell git describe --tags --abbrev=0)" -o ./bin/genval .
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o ./bin/genval .

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"runtime"
 
-	"github.com/containerd/containerd/platforms"
-	"github.com/fatih/color"
-	"github.com/intelops/genval/pkg/utils"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/release-utils/version"
 )
 
 var versionCmd = &cobra.Command{
@@ -15,29 +12,11 @@ var versionCmd = &cobra.Command{
 	Short: "Prints Genval version information",
 	Long:  `All software has versions. This is Genval's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		version, commitHash, buildTime, err := utils.FetchVersionInfo()
+		vCmd := version.Version()
+		err := vCmd.RunE(cmd, args)
 		if err != nil {
-			return
+			fmt.Println("Error:", err)
 		}
-		color.New(color.FgHiCyan, color.Bold).Println(`
-		:'######:::'########:'##::: ##:'##::::'##::::'###::::'##:::::::
-		:##... ##:: ##.....:: ###:: ##: ##:::: ##:::'## ##::: ##:::::::
-		:##:::..::: ##::::::: ####: ##: ##:::: ##::'##:. ##:: ##:::::::
-		:##::'####: ######::: ## ## ##: ##:::: ##:'##:::. ##: ##:::::::
-		:##::: ##:: ##...:::: ##. ####:. ##:: ##:: #########: ##:::::::
-		:##::: ##:: ##::::::: ##:. ###::. ## ##::: ##.... ##: ##:::::::
-		: ######::: ########: ##::. ##:::. ###:::: ##:::: ##: ########:
-		:......::::........::..::::..:::::...:::::..:::::..::........::
-
-		genval is a CLI tool to generate and validate configuration files
-
-		`)
-		fmt.Printf("Version:\t%s\n", version)
-		fmt.Printf("Git Commit:\t%s\n", commitHash)
-		fmt.Printf("OS/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
-		fmt.Printf("Go version:\t%s\n", runtime.Version())
-		fmt.Printf("Build date:\t%s\n", buildTime)
-		fmt.Printf("Build platform:\t%s\n", platforms.DefaultString())
 	},
 }
 

--- a/pkg/oci/ociClient.go
+++ b/pkg/oci/ociClient.go
@@ -298,7 +298,7 @@ func GetCreds() ([]crane.Option, error) {
 		opts = append(opts, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
-	userAgent, _, _, err := utils.FetchVersionInfo()
+	userAgent, err := utils.GetVersion()
 	if err != nil {
 		log.Errorf("Error fetching version info: %v", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -409,37 +409,21 @@ func StartSpinner(msg string) *spinner.Spinner {
 	return s
 }
 
-func FetchVersionInfo() (string, string, string, error) {
-	// Create the command to list all tags and get the latest one
+func GetVersion() (string, error) {
+	// Create the command to list all tag
 	cmdGitRevList := exec.Command("git", "rev-list", "--tags", "--max-count=1")
 	var out bytes.Buffer
 	cmdGitRevList.Stdout = &out
 	if err := cmdGitRevList.Run(); err != nil {
-		return "", "", "", fmt.Errorf("error running git rev-list: %v", err)
+		return "", fmt.Errorf("error running git rev-list: %v", err)
 	}
-	latestTagCommit := strings.TrimSpace(out.String())
+	latestTag := strings.TrimSpace(out.String())
 
-	// Create the command to fetch the latest tag using the commit hash
-	cmdGitDescribe := exec.Command("git", "describe", "--tags", latestTagCommit)
-	versionOutput, err := cmdGitDescribe.Output()
+	// Create the command to fetc the latest tag
+	cmdGitDescribe := exec.Command("git", "describe", "--tags", latestTag)
+	version, err := cmdGitDescribe.Output()
 	if err != nil {
-		return "", "", "", fmt.Errorf("error running git describe: %v", err)
+		return "", fmt.Errorf("error running git describe: %v", err)
 	}
-	latestTag := strings.TrimSpace(string(versionOutput))
-
-	// Get the commit date for the latest tag
-	cmdGitLog := exec.Command("git", "log", "-1", "--format=%cI", latestTagCommit)
-	dateOutput, err := cmdGitLog.Output()
-	if err != nil {
-		return "", "", "", fmt.Errorf("error running git log: %v", err)
-	}
-	commitDateRaw := strings.TrimSpace(string(dateOutput))
-	// Parse the commit date and format it using time.ANSIC
-	commitDate, err := time.Parse(time.RFC3339, commitDateRaw)
-	if err != nil {
-		return "", "", "", fmt.Errorf("error parsing commit date: %v", err)
-	}
-	formattedCommitDate := commitDate.Format(time.ANSIC)
-
-	return latestTag, latestTagCommit, formattedCommitDate, nil
+	return string(version), nil
 }


### PR DESCRIPTION
The previous update to the version command did not retrieve build information as intended. This pull request now incorporates the retrieval of build information, similar to the functionality found in the `sig-k8s/release-utils` library.