### PR TITLE
Enhance printing of results of Rego evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ genval
 cosign
 .todo
 !.devcontainer/Dockerfile
+results.json

--- a/pkg/validate/celval.go
+++ b/pkg/validate/celval.go
@@ -54,6 +54,9 @@ func EvaluateCELPolicies(policies []CELPolicy, inputFile string, t table.Writer)
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
 
+	var allResults []Results
+	var idCounter int
+
 	for _, policy := range policies {
 		result, err := evaluateCEL(inputFile, policy.Rule)
 		var resultColorized string
@@ -72,6 +75,21 @@ func EvaluateCELPolicies(policies []CELPolicy, inputFile string, t table.Writer)
 			policy.Metadata.Severity,
 			policy.Metadata.Benchmark,
 		})
+		idCounter++
+		allResults = append(allResults, Results{
+			ID:          fmt.Sprintf("%d", idCounter),
+			PolicyName:  policy.Metadata.Name,
+			Status:      resultColorized,
+			Description: policy.Metadata.Description,
+			Severity:    policy.Metadata.Severity,
+			Benchmark:   policy.Metadata.Benchmark,
+		})
+	}
+
+	if len(allResults) > 0 {
+		if err := SaveResults("results.json", allResults); err != nil {
+			return fmt.Errorf("error saving results: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/validate/printresults.go
+++ b/pkg/validate/printresults.go
@@ -19,16 +19,15 @@ func PrintResults(result rego.ResultSet, metas []*regoMetadata) error {
 
 	var policyError error
 
-	// Match policy metadata outside the loop
-	matchedKey, meta, err := MatchPolicyMetadata(metas, result)
-	if err != nil {
-		return fmt.Errorf("error matching key and metadata name: %v", err)
-	}
-
 	for _, r := range result {
 		if len(r.Expressions) > 0 {
 			keys := r.Expressions[0].Value.(map[string]interface{})
 			for key, value := range keys {
+				// Match policy metadata for each key
+				matchedKey, meta, err := MatchPolicyMetadata(metas, key)
+				if err != nil {
+					return fmt.Errorf("error matching key and metadata name: %v", err)
+				}
 				// Construct rows using the matched metadata
 				if key == matchedKey {
 					var status string
@@ -58,8 +57,22 @@ func PrintResults(result rego.ResultSet, metas []*regoMetadata) error {
 		}
 	}
 
-	// Render the table
 	t.Render()
 
 	return policyError
+}
+
+type Results struct {
+	ID          string `json:"id"`
+	PolicyName  string `json:"policyName"`
+	Resource    string `json:"resourceName"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	Benchmark   string `json:"benchmark"`
+	Category    string `json:"category"`
+}
+
+func (r *Results) SaveResults() error {
+	return nil
 }

--- a/pkg/validate/regometa.go
+++ b/pkg/validate/regometa.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/open-policy-agent/opa/rego"
 )
 
 func FetchRegoMetadata(policyDir, metaExt, regoExt string) ([]string, []string, error) {
@@ -60,18 +58,11 @@ func LoadRegoMetadata(filePaths []string) ([]*regoMetadata, error) {
 }
 
 // MatchPolicyMetadata matches the RegoMeta policy names with the Rego evaluation results and returns the matched key
-func MatchPolicyMetadata(metas []*regoMetadata, results rego.ResultSet) (string, *regoMetadata, error) {
-	for _, r := range results {
-		if len(r.Expressions) > 0 {
-			keys := r.Expressions[0].Value.(map[string]interface{})
-			for key := range keys {
-				for _, meta := range metas {
-					if key == meta.PolicyName {
-						return key, meta, nil
-					}
-				}
-			}
+func MatchPolicyMetadata(metas []*regoMetadata, key string) (string, *regoMetadata, error) {
+	for _, meta := range metas {
+		if key == meta.PolicyName {
+			return key, meta, nil
 		}
 	}
-	return "", nil, fmt.Errorf("no matching policy name found")
+	return "", nil, fmt.Errorf("no matching policy name found for key: %s", key)
 }

--- a/pkg/validate/results.json
+++ b/pkg/validate/results.json
@@ -1,0 +1,12 @@
+{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}

--- a/pkg/validate/results.json
+++ b/pkg/validate/results.json
@@ -1,12 +1,11 @@
-{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"deny_latest","status":"passed","description":"Ensure images are pinned to a specific version/digest","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
-{"id":"1","policyName":"multi_stage","status":"passed","description":"Use multi-stage Docker builds to minimize size and performance","severity":"High","benchmark":"CIS-4.2","category":"Infrastructure security"}
+[
+  {
+    "id": "1",
+    "policyName": "multi_stage",
+    "status": "passed",
+    "description": "Use multi-stage Docker builds to minimize size and performance",
+    "severity": "High",
+    "benchmark": "CIS-4.2",
+    "category": "Infrastructure security"
+  }
+]

--- a/pkg/validate/testdata/rego/test/deny_latest.json
+++ b/pkg/validate/testdata/rego/test/deny_latest.json
@@ -3,7 +3,7 @@
   "policy_file": "deny_latest.rego",
   "policy_name": "deny_latest",
   "severity": "High",
-  "Description": "Ensure images are pinned to a specific version/digest",
+  "Description": "Image does not have latest tag",
   "Benchmark": "CIS-4.2",
   "Category": "Infrastructure security"
 }

--- a/pkg/validate/validatedockerfile.go
+++ b/pkg/validate/validatedockerfile.go
@@ -14,7 +14,6 @@ import (
 )
 
 // ValidateDockerfileUsingRego validates a Dockerfile using Rego.
-// ValidateDockerfileUsingRego validates a Dockerfile using Rego.
 func ValidateDockerfile(dockerfileContent string, regoPolicyPath string) error {
 	metaFiles, regoPolicy, err := FetchRegoMetadata(regoPolicyPath, metaExt, policyExt)
 	if err != nil {
@@ -28,7 +27,7 @@ func ValidateDockerfile(dockerfileContent string, regoPolicyPath string) error {
 	}
 
 	// Declare a slice to store the results of each policy evaluation
-	var allResults []rego.ResultSet
+	var allResults rego.ResultSet
 
 	for _, regoFile := range regoPolicy {
 		dockerPolicy, err := utils.ReadFile(regoFile)
@@ -38,7 +37,7 @@ func ValidateDockerfile(dockerfileContent string, regoPolicyPath string) error {
 
 		pkg, err := utils.ExtractPackageName(dockerPolicy)
 		if err != nil {
-			return fmt.Errorf("errr fetching package name from polcy %v: %v", dockerPolicy, err)
+			return fmt.Errorf("error fetching package name from policy %v: %v", dockerPolicy, err)
 		}
 
 		// Prepare Rego input data
@@ -88,14 +87,12 @@ func ValidateDockerfile(dockerfileContent string, regoPolicyPath string) error {
 		}
 
 		// Store the results in the slice
-		allResults = append(allResults, rs)
+		allResults = append(allResults, rs...)
 	}
 
 	// Print all results accumulated from each policy evaluation
-	for _, rs := range allResults {
-		if err := PrintResults(rs, metas); err != nil {
-			return fmt.Errorf("error evaluating rego results for %s: %v", regoPolicyPath, err)
-		}
+	if err := PrintResults(allResults, metas); err != nil {
+		return fmt.Errorf("error evaluating rego results for %s: %v", regoPolicyPath, err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes a bug that caused p the results of Rego evaluations to be printed in separate tables.
Now, all the results of Rego evaluations are printed in a single table as shown below.

![rego-eval-print](https://github.com/intelops/genval/assets/141515226/7ff661c9-44ae-493a-8860-7d7c4a501527)

Additionally, this PR introduces functionality to store the results of both CEL and Rego evaluations in a local file named results.json.

Closes: #77 and #80 
