### PR TITLE
Fix: artifact commands failing due to incorrect userAgent formatting

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -425,5 +425,6 @@ func GetVersion() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error running git describe: %v", err)
 	}
-	return string(version), nil
+	userAgent := fmt.Sprintf("intelops/genval: %s", string(version))
+	return strings.ReplaceAll(userAgent, "\n", ""), nil
 }

--- a/templates/defaultpolicies/contest.rego
+++ b/templates/defaultpolicies/contest.rego
@@ -1,0 +1,15 @@
+package main
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.securityContext.runAsNonRoot
+
+  msg := "Containers must not run as root"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.selector.matchLabels.app
+
+  msg := "Containers must provide app label for pod selectors"
+}

--- a/templates/defaultpolicies/rego/k8s/deny_latest/deny_latest.json
+++ b/templates/defaultpolicies/rego/k8s/deny_latest/deny_latest.json
@@ -1,0 +1,12 @@
+{
+  "name": "DenyLatest",
+  "policy_file": "k8s.rego",
+  "policy_name": "deny_latest",
+  "severity": "High",
+  "Description": "Ensure Image does not use 'latest' tag",
+  "Benchmark": "CIS-4.9",
+  "Category": "Infrastructure security"
+}
+
+
+

--- a/templates/defaultpolicies/rego/k8s/deny_latest/deny_latest.rego
+++ b/templates/defaultpolicies/rego/k8s/deny_latest/deny_latest.rego
@@ -1,0 +1,48 @@
+package validate_k8s
+
+import rego.v1
+
+
+deny_latest contains msg if {
+input.kind ==	"Deployment"
+c:= input.spec.template.spec.containers[i].image
+not endswith(c, "latest")
+msg:= "Image does not use 'latest' tag"
+}
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     not container.envFrom
+#     msg:= "Deployment does not use 'envFrom'"
+# }
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     env := container.envFrom[_]
+#     not env.secretRef
+#     msg:= "Deployment does not use 'secretRef' in ENV"
+# 	}
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     env := container.env[_]
+# 	env.valueFrom != []
+#     msg:= "Deployment does not use 'valueFrom' in ENV"
+# }
+
+# deny_priviliged_pod contains msg if {
+# 	input.kind == "Deployment"
+# 	not input.spec.template.spec.securityContext
+#     msg:= "Deployment does not use priviliged pod"
+# }
+
+# deny_priviliged_pod contains msg if {
+# 	input.kind == "Deployment"
+# 	podSpec := input.spec.template.spec.securityContext
+
+# 	not podSpec.priviliged
+#     msg:= "Deployment does not use priviliged pod"
+# }

--- a/templates/defaultpolicies/rego/k8s/deny_secret/deny_secret.json
+++ b/templates/defaultpolicies/rego/k8s/deny_secret/deny_secret.json
@@ -1,0 +1,9 @@
+{
+  "name": "DenySecret",
+  "policy_file": "k8s.rego",
+  "policy_name": "deny_priviliged_pod",
+  "severity": "High",
+  "Description": "Ensure Deployment does not use 'secretRef' in ENV",
+  "Benchmark": "CIS-4.9",
+  "Category": "Infrastructure security"
+}

--- a/templates/defaultpolicies/rego/k8s/deny_secret/deny_secret.rego
+++ b/templates/defaultpolicies/rego/k8s/deny_secret/deny_secret.rego
@@ -1,0 +1,48 @@
+package validate_k8s
+
+import rego.v1
+
+
+# deny_latest contains msg if {
+# input.kind ==	"Deployment"
+# c:= input.spec.template.spec.containers[i].image
+# not endswith(c, "latest")
+# msg:= "Image does not use 'latest' tag"
+# }
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     not container.envFrom
+#     msg:= "Deployment does not use 'envFrom'"
+# }
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     env := container.envFrom[_]
+#     not env.secretRef
+#     msg:= "Deployment does not use 'secretRef' in ENV"
+# 	}
+
+# deny_secret contains msg if {
+#     input.kind == "Deployment"
+#     container := input.spec.template.spec.containers[_]
+#     env := container.env[_]
+# 	env.valueFrom != []
+#     msg:= "Deployment does not use 'valueFrom' in ENV"
+# }
+
+deny_priviliged_pod contains msg if {
+	input.kind == "Deployment"
+	not input.spec.template.spec.securityContext
+    msg:= "Deployment does not use priviliged pod"
+}
+
+# deny_priviliged_pod contains msg if {
+# 	input.kind == "Deployment"
+# 	podSpec := input.spec.template.spec.securityContext
+
+# 	not podSpec.priviliged
+#     msg:= "Deployment does not use priviliged pod"
+# }


### PR DESCRIPTION
Atrifact push and pull commands were failing due to incorrect formatting of the `User-Agent` value in HTTP headers while making calls to container registries.
This PR fixes the bug now both the artifact commands work as expected.