### PR TITLE
Update ldflags in goreleaser to capture build info during release

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+K8S_1.29="ghcr.io/santoshkal/artifacts/cuemods/cuemod-k8sv:1.29"
+DOCKERFILEPOLICIES = "ghcr.io/santoshkal/genval-security-policies/rego-policies:v0.0.1"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cosign
 .todo
 !.devcontainer/Dockerfile
 results.json
+.env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,13 +16,10 @@ builds:
     # trims path
     - -trimpath
   ldflags:
-  #   # CommitDate makes the release reproducible
-    - -X main.Version={{ .Tag }}
-    - -X .Runtime.Goarch={{ .Arch }}
-    - -X .Runtime.Gooss={{ .Os }}
-    - -X main.Date={{ .CommitDate }}
-    - -X main.Commit={{ .FullCommit }}
-    - -X main.GitTreeState={{ .GitTreeState }}
+  - -X sigs.k8s.io/release-utils/version.gitVersion={{ .Tag }}
+  - -X sigs.k8s.io/release-utils/version.gitCommit={{ .FullCommit }}
+  - -X sigs.k8s.io/release-utils/version.gitTreeState={{ .GitTreeState }}
+  - -X sigs.k8s.io/release-utils/version.buildDate={{ .Date }}
 
 
 checksum:


### PR DESCRIPTION
Update ldflags in `goreleaser.yaml` to capture build info during the release workflow.