### PR TITLE
Add cred flag to pull and push commands

### DIFF
--- a/cmd/artifact_pull.go
+++ b/cmd/artifact_pull.go
@@ -70,7 +70,7 @@ func init() {
 	pullCmd.Flags().StringVarP(&pullArgs.dest, "dest", "d", "", "destination URL for pulling the artifact from")
 	pullCmd.Flags().BoolVarP(&pullArgs.verify, "verify", "v", false, "Set signature verification of the artifact using Sigstore cosign")
 	pullCmd.Flags().StringVarP(&pullArgs.cosignKey, "pub-key", "k", "", "Cosign public key for varifying the artifact")
-	pushCmd.Flags().StringVarP(&pushArgs.creds, "credentials", "c", "", "Credentials to authenticate with OCI registries ")
+	pullCmd.Flags().StringVarP(&pullArgs.creds, "credentials", "c", "", "Credentials to authenticate with OCI registries ")
 	artifactCmd.AddCommand(pullCmd)
 }
 

--- a/cmd/artifact_pull.go
+++ b/cmd/artifact_pull.go
@@ -60,6 +60,7 @@ type pullFlags struct {
 	dest      string
 	verify    bool
 	cosignKey string
+	creds     string
 }
 
 var pullArgs pullFlags
@@ -69,7 +70,7 @@ func init() {
 	pullCmd.Flags().StringVarP(&pullArgs.dest, "dest", "d", "", "destination URL for pulling the artifact from")
 	pullCmd.Flags().BoolVarP(&pullArgs.verify, "verify", "v", false, "Set signature verification of the artifact using Sigstore cosign")
 	pullCmd.Flags().StringVarP(&pullArgs.cosignKey, "pub-key", "k", "", "Cosign public key for varifying the artifact")
-
+	pushCmd.Flags().StringVarP(&pushArgs.creds, "credentials", "c", "", "Credentials to authenticate with OCI registries ")
 	artifactCmd.AddCommand(pullCmd)
 }
 

--- a/cmd/artifact_push.go
+++ b/cmd/artifact_push.go
@@ -66,6 +66,7 @@ type pushFlags struct {
 	annotations []string
 	sign        bool
 	cosignKey   string
+	creds       string
 }
 
 var pushArgs pushFlags
@@ -82,6 +83,7 @@ func init() {
 	pushCmd.Flags().StringArrayVarP(&pushArgs.annotations, "annotations", "a", nil, "Set custom annotation in <key>=<value> format")
 	pushCmd.Flags().BoolVarP(&pushArgs.sign, "sign", "s", false, "If set to true, signs the artifact with cosign in keyless mode")
 	pushCmd.Flags().StringVarP(&pushArgs.cosignKey, "cosign-key", "k", "", "path to cosign private key")
+	pushCmd.Flags().StringVarP(&pushArgs.creds, "credentials", "c", "", "Credentials to authenticate with OCI registries ")
 	artifactCmd.AddCommand(pushCmd)
 }
 
@@ -149,7 +151,6 @@ func runPushCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Errorf("appending content to artifact failed: %v", err)
 	}
-	// TODO: Add userAgent header for HTTP requests made to OCI registry
 	spin := utils.StartSpinner("pushing artifact")
 	defer spin.Stop()
 	opts, err := oci.GetCreds()

--- a/pkg/oci/ociClient.go
+++ b/pkg/oci/ociClient.go
@@ -189,8 +189,6 @@ func PullArtifact(ctx context.Context, dest, path string) error {
 	url := parts[0]
 	desiredTag := parts[1]
 
-	// TODO: Add userAgent header for HTTP requests made to OCI registry
-
 	opts, err := GetCreds()
 	if err != nil {
 		return fmt.Errorf("error getting credentials: %v", err)


### PR DESCRIPTION
This PR Adds `creds` flag to push and pull commands. Now Push/pull commands accept creds in the form of `ARTIFACT_REGISTRY_USERNAME`, `ARTIFACT_REGISTRY_PASSWORD` env vars or REgistry PAT as `ARTIFACT_REGISTRY_TOKEN` or provide the PAT as string.
If none of these are provided. the creds will default to `defaultKeyChain` of looking up to `$HOME/.docker/config.json` for authentication. 