### PR TITLE
Bump go version from 1.21 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/intelops/genval
 
-go 1.21
+go 1.22.0
+
 toolchain go1.22.4
 
 require (


### PR DESCRIPTION
Bump go version from 1.21 to 1.22 in go,mod