### PR TITLE
Update CI and Release workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: "1.22"
           cache: false
       - name: Run tests
         run: go test ./... -coverprofile=coverage.out -coverpkg=./... -covermode=atomic
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6
         with:
           version: v1.59
           args: -v --config=.ci.yml
@@ -33,13 +33,13 @@ jobs:
           skip-build-cache: true
 
       - name: Static check
-        uses: dominikh/staticcheck-action@v1.3.1
+        uses: dominikh/staticcheck-action@5106bb8ba1333e0510c91b2aa44c5ede005d9cff # v1.3.1
         with:
           version: "2023.1.6"
           install-go: false
           cache-key: "1.22"
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # 0.24.0
         with:
           scan-type: "fs"
           ignore-unfixed: true
@@ -47,6 +47,6 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@02ab1d05e391b5778f6ca0b68022bb05ec6481fa # v3
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,19 +19,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: 1.22 # Go version
           cache: true
       - name: Run tests
         run: go test ./... -coverprofile=coverage.out -coverpkg=./... -covermode=atomic
 
-      - uses: sigstore/cosign-installer@v3.5 # installs cosign
-      - uses: anchore/sbom-action/download-syft@v0.16 # installs syft
-      - uses: goreleaser/goreleaser-action@v6 # run goreleaser
+      - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5 # installs cosign
+      - uses: anchore/sbom-action/download-syft@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17 installs syft
+      - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6 # run goreleaser
         id: goreleaser
         with:
           version: latest


### PR DESCRIPTION
- Update all the 3rd party actions with pinned commit hashes
- Update Dependabot config to track github action updates as well
Closes #128 